### PR TITLE
Check ViewHolder is still bound to the item before returning it

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    compileSdkVersion compileSdk
+    buildToolsVersion buildTools
 
     defaultConfig {
-        applicationId "com.fueled.reclaim"
-        minSdkVersion 15
-        targetSdkVersion 24
+        applicationId appId
+        minSdkVersion minSdk
+        targetSdkVersion targetSdk
         versionCode 1
         versionName "1.0"
     }
@@ -23,7 +23,9 @@ dependencies {
     compile project(':reclaim')
 
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
-    compile 'com.android.support:recyclerview-v7:24.2.0'
+
+    testCompile testLibraries.junit
+
+    compile libraries.appCompat
+    compile libraries.recyclerView
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+apply from: "extra/gradle/libraries.gradle"
 
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/extra/gradle/libraries.gradle
+++ b/extra/gradle/libraries.gradle
@@ -1,0 +1,39 @@
+ext {
+
+    //app
+    compileSdk = 25
+    buildTools = "25.0.2"
+    minSdk = 15
+    targetSdk = 25
+    appId = "com.fueled.reclaim"
+
+    //android libraries
+    supportVersion = '25.2.0'
+
+    //test libraries
+    junitVersion = '4.12'
+    tesetRunnerVersion = '0.5'
+    hamcrestVersion = '1.4-atlassian-1'
+    espressoVersion = '2.2.2'
+    mockitoVersion = '1.10.19'
+    mockitoVersion = '1.10.19'
+
+
+    libraries = [
+            appCompat    : "com.android.support:appcompat-v7:${supportVersion}",
+            recyclerView : "com.android.support:recyclerview-v7:${supportVersion}",
+            designSupport: "com.android.support:design:${supportVersion}",
+            vectorSupport: "com.android.support:support-vector-drawable:${supportVersion}",
+    ]
+
+    testLibraries = [
+            junit             : "junit:junit:${junitVersion}",
+            supportAnnotations: "com.android.support:support-annotations:${supportVersion}",
+            testRunner        : "com.android.support.test:runner:${tesetRunnerVersion}",
+            testRule          : "com.android.support.test:rules:${tesetRunnerVersion}",
+            hamcrest          : "org.hamcrest:hamcrest-library:${hamcrestVersion}",
+            espresso          : "com.android.support.test.espresso:espresso-core:${espressoVersion}",
+            mockito           : "org.mockito:mockito-core:${mockitoVersion}"
+    ]
+
+}

--- a/extra/gradle/libraries.gradle
+++ b/extra/gradle/libraries.gradle
@@ -16,7 +16,6 @@ ext {
     hamcrestVersion = '1.4-atlassian-1'
     espressoVersion = '2.2.2'
     mockitoVersion = '1.10.19'
-    mockitoVersion = '1.10.19'
 
 
     libraries = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 09 16:28:19 EDT 2016
+#Wed Mar 08 18:21:21 GMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/reclaim/build.gradle
+++ b/reclaim/build.gradle
@@ -5,12 +5,12 @@ group = 'com.github.fueled'
 version = '1.0.0'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    compileSdkVersion compileSdk
+    buildToolsVersion buildTools
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 24
+        minSdkVersion minSdk
+        targetSdkVersion targetSdk
         versionCode 100
         versionName "1.0.0"
     }
@@ -33,10 +33,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:recyclerview-v7:24.2.1'
+    compile libraries.recyclerView
 
     //tests
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.hamcrest:hamcrest-library:1.4-atlassian-1'
+    testCompile testLibraries.junit
+    testCompile testLibraries.mockito
+    testCompile testLibraries.hamcrest
 }

--- a/reclaim/src/main/java/com/fueled/reclaim/BaseItem.java
+++ b/reclaim/src/main/java/com/fueled/reclaim/BaseItem.java
@@ -12,11 +12,11 @@ public abstract class BaseItem<T1, T2, T3 extends BaseViewHolder> {
     protected int layoutId;
     protected ItemHandlerProvider<T2> itemHandlerProvider;
 
-    T1 data;
-    T3 viewHolder;
+    private T1 data;
+    private T3 viewHolder;
 
-    int positionInAdapter;
-    boolean isLastItem;
+    private int positionInAdapter;
+    private boolean isLastItem;
 
 
     /**
@@ -139,7 +139,12 @@ public abstract class BaseItem<T1, T2, T3 extends BaseViewHolder> {
      * @return the view holder currently attached to this item
      */
     public T3 getViewHolder() {
-        return viewHolder;
+        if (viewHolder != null && viewHolder.getItemBoundTo() == getPositionInAdapter()) {
+            // Make sure the view holder is still bound to this item before returning it.
+            return viewHolder;
+        }
+
+        return null;
     }
 
 }

--- a/reclaim/src/main/java/com/fueled/reclaim/BaseViewHolder.java
+++ b/reclaim/src/main/java/com/fueled/reclaim/BaseViewHolder.java
@@ -9,8 +9,17 @@ import android.view.View;
  */
 public abstract class BaseViewHolder extends RecyclerView.ViewHolder {
 
+    private int itemBoundTo;
+
     public BaseViewHolder(View view) {
         super(view);
     }
 
+    public int getItemBoundTo() {
+        return itemBoundTo;
+    }
+
+    public void setItemBoundTo(int itemBoundTo) {
+        this.itemBoundTo = itemBoundTo;
+    }
 }

--- a/reclaim/src/main/java/com/fueled/reclaim/ItemsViewAdapter.java
+++ b/reclaim/src/main/java/com/fueled/reclaim/ItemsViewAdapter.java
@@ -125,6 +125,7 @@ public class ItemsViewAdapter extends RecyclerView.Adapter<BaseViewHolder> {
     @Override
     @SuppressWarnings("unchecked")
     public void onBindViewHolder(BaseViewHolder holder, int position) {
+        holder.setItemBoundTo(position);
         items.get(position).onBindViewHolder(holder);
     }
 


### PR DESCRIPTION
# Description
* Fix issue where once we bind a `ViewHolder` to a `BaseItem` the bound is never removed even if the same `ViewHolder` was bonded to a different `BaseItem`.
* Update libraries and build tools versions.
* Move libraries to `libraries.gradle`.