### PR TITLE
Fix logic for setting and checking item position

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/reclaim/src/main/java/com/fueled/reclaim/BaseItem.java
+++ b/reclaim/src/main/java/com/fueled/reclaim/BaseItem.java
@@ -50,9 +50,8 @@ public abstract class BaseItem<T1, T2, T3 extends BaseViewHolder> {
      *
      * @return the layout id to be used by the item
      */
-    abstract public
     @LayoutRes
-    int getLayoutId();
+    abstract public int getLayoutId();
 
     /**
      * Let the caller know the item is the last one in the adapter
@@ -96,8 +95,7 @@ public abstract class BaseItem<T1, T2, T3 extends BaseViewHolder> {
      *
      * @param viewHolder the view holder to bind to this item
      */
-    public void onBindViewHolder(T3 viewHolder, int positionInAdapter) {
-        this.positionInAdapter = positionInAdapter;
+    public void onBindViewHolder(T3 viewHolder) {
         this.viewHolder = viewHolder;
         updateItemViews();
     }
@@ -140,7 +138,7 @@ public abstract class BaseItem<T1, T2, T3 extends BaseViewHolder> {
      * @return the view holder currently attached to this item
      */
     public T3 getViewHolder() {
-        if (viewHolder != null && viewHolder.getItemBoundTo() == getPositionInAdapter()) {
+        if (viewHolder != null && viewHolder.getAdapterPosition() == getPositionInAdapter()) {
             // Make sure the view holder is still bound to this item before returning it.
             return viewHolder;
         }

--- a/reclaim/src/main/java/com/fueled/reclaim/BaseViewHolder.java
+++ b/reclaim/src/main/java/com/fueled/reclaim/BaseViewHolder.java
@@ -9,17 +9,8 @@ import android.view.View;
  */
 public abstract class BaseViewHolder extends RecyclerView.ViewHolder {
 
-    private int itemBoundTo;
-
     public BaseViewHolder(View view) {
         super(view);
     }
 
-    public int getItemBoundTo() {
-        return itemBoundTo;
-    }
-
-    public void setItemBoundTo(int itemBoundTo) {
-        this.itemBoundTo = itemBoundTo;
-    }
 }


### PR DESCRIPTION
# Description

Previously we were relying on `onBindViewHolder` to be called to update an item position, but there are cases were the item position would change without `onBindViewHolder` being called especially when using animations. To avoid this, we are now making sure that item positions are updated every time the items list is updated.