### PR TITLE
Add method to get all items from adapter

### DIFF
--- a/reclaim/build.gradle
+++ b/reclaim/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 group = 'com.github.fueled'
-version = '1.2.1'
+version = '1.2.2'
 
 android {
     compileSdkVersion compileSdk

--- a/reclaim/src/main/java/com/fueled/reclaim/ItemsViewAdapter.java
+++ b/reclaim/src/main/java/com/fueled/reclaim/ItemsViewAdapter.java
@@ -150,6 +150,13 @@ public class ItemsViewAdapter extends RecyclerView.Adapter<BaseViewHolder> {
         return items.get(position);
     }
 
+    /**
+     * Returns a list of all items currently in the adapter
+     */
+    public List<BaseItem> getItems() {
+        return items;
+    }
+
     @Override
     public BaseViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
 


### PR DESCRIPTION
> Why was this change necessary?

Currently, the only way to loop through all items is using an external iterator and getting each item via its index. 
```Kotlin
(0 until adapter.itemCount)
        .forEach { adapter.getItem(it) }
```

> How does it address the problem?

Provides a simple way to iterate over the entire list of items. To the user of this API, it would look like:
```Kotlin
adapter.items.forEach { ... } 
```

> Are there any side effects?

no

> Do you want a specific feedback?

thoughts

> Related resources?

none