### PR TITLE
Remove the need to pass context when creating a new ItemsViewAdapter

### DIFF
--- a/app/src/main/kotlin/com/fueled/reclaim/samples/MainActivity.kt
+++ b/app/src/main/kotlin/com/fueled/reclaim/samples/MainActivity.kt
@@ -17,7 +17,7 @@ import com.fueled.reclaim.samples.notes.NotesStorage
 class MainActivity : AppCompatActivity() {
 
     private lateinit var recyclerView: RecyclerView
-    private lateinit var adapter: ItemsViewAdapter
+    private val adapter = ItemsViewAdapter()
 
     private val cardColors = listOf(0xffe1f5fe, 0xfffffde7, 0xfffbe9e7, 0xffefebe9, 0xfff3e5f5)
 
@@ -35,9 +35,7 @@ class MainActivity : AppCompatActivity() {
 
         recyclerView.layoutManager = layoutManager
 
-
         //set adapter
-        adapter = ItemsViewAdapter(this)
         recyclerView.adapter = adapter
 
         subscribeToNoteUpdates()

--- a/extra/gradle/jacoco.gradle
+++ b/extra/gradle/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.2"
+    toolVersion = "0.8.3"
 }
 
 ext {

--- a/reclaim/src/main/kotlin/com/fueled/reclaim/ItemsViewAdapter.kt
+++ b/reclaim/src/main/kotlin/com/fueled/reclaim/ItemsViewAdapter.kt
@@ -26,7 +26,6 @@ import java.util.ArrayList
 
 @Suppress("unused", "MemberVisibilityCanBePrivate") // Public API.
 open class ItemsViewAdapter @JvmOverloads constructor(
-    private val context: Context,
     private val items: MutableList<AdapterItem<*>> = ArrayList()
 ) : RecyclerView.Adapter<BaseViewHolder>(), Iterable<AdapterItem<*>> {
 
@@ -165,7 +164,7 @@ open class ItemsViewAdapter @JvmOverloads constructor(
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): BaseViewHolder {
         for (item in items) {
             if (item.layoutId == viewType) {
-                val view = getLayoutInflater()
+                val view = getLayoutInflater(viewGroup.context)
                     .inflate(item.layoutId, viewGroup, false)
 
                 return item.onCreateViewHolder(view)
@@ -196,5 +195,5 @@ open class ItemsViewAdapter @JvmOverloads constructor(
     ) = DiffChecker(oldItemsList, newItemsList)
 
     @VisibleForTesting
-    internal fun getLayoutInflater() = LayoutInflater.from(context)
+    internal fun getLayoutInflater(context: Context) = LayoutInflater.from(context)
 }

--- a/reclaim/src/test/kotlin/com/fueled/reclaim/ItemsViewAdapterTest.kt
+++ b/reclaim/src/test/kotlin/com/fueled/reclaim/ItemsViewAdapterTest.kt
@@ -35,7 +35,7 @@ class ItemsViewAdapterTest {
 
     @Before
     fun setup() {
-        itemsAdapter = spy(ItemsViewAdapter(context))
+        itemsAdapter = spy(ItemsViewAdapter())
 
         doReturn(diffChecker).whenever(itemsAdapter).getDiffChecker(any(), any())
     }
@@ -253,13 +253,15 @@ class ItemsViewAdapterTest {
         // Given
         doNothing().whenever(itemsAdapter).notifyItemRangeInserted(any(), any())
 
-        val viewGroup: ViewGroup = mock()
+        val viewGroup: ViewGroup = mock {
+            on { context } doReturn context
+        }
         val view: View = mock()
         val layoutInflater: LayoutInflater = mock {
             on { inflate(TestsMockFactory.TEST_2_ADAPTER_ID, viewGroup, false) } doReturn view
         }
 
-        doReturn(layoutInflater).whenever(itemsAdapter).getLayoutInflater()
+        doReturn(layoutInflater).whenever(itemsAdapter).getLayoutInflater(context)
 
         val viewHolder: BaseViewHolder = mock()
         val viewHolder2: BaseViewHolder = mock()
@@ -282,7 +284,7 @@ class ItemsViewAdapterTest {
         val vh = itemsAdapter.onCreateViewHolder(viewGroup, TestsMockFactory.TEST_2_ADAPTER_ID)
 
         // Then
-        verify(itemsAdapter).getLayoutInflater()
+        verify(itemsAdapter).getLayoutInflater(context)
         verify(layoutInflater).inflate(TestsMockFactory.TEST_2_ADAPTER_ID, viewGroup, false)
         verify(type2AdapterItem).onCreateViewHolder(view)
         verify(type1AdapterItem, never()).onCreateViewHolder(view)


### PR DESCRIPTION
## Description

Remove need to pass a `Context` object when creating a new `ItemsViewAdapter` as we can use the context from the parent `ViewGroup` when inflating an item layout. This will also help remove any possibility leaking the context object.