### PR TITLE
feat(*): make update item views optional

### DIFF
--- a/app/src/main/kotlin/com/fueled/reclaim/samples/MainActivity.kt
+++ b/app/src/main/kotlin/com/fueled/reclaim/samples/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.fueled.reclaim.ItemsViewAdapter
 import com.fueled.reclaim.samples.items.HeaderAdapterItem
 import com.fueled.reclaim.samples.items.NoteAdapterItem
+import com.fueled.reclaim.samples.items.LoadingAdapterItem
 import com.fueled.reclaim.samples.notes.Note
 import com.fueled.reclaim.samples.notes.NotesStorage
 
@@ -52,7 +53,7 @@ class MainActivity : AppCompatActivity() {
         val items = listOf(HeaderAdapterItem("Elliot Alderson")) + notes
             .mapIndexed { index, note ->
                 NoteAdapterItem(note, cardColors[index % cardColors.size].toInt(), ::onDeleteNote)
-            }
+            } + listOf(LoadingAdapterItem())
 
         adapter.replaceItems(
             items = items,

--- a/app/src/main/kotlin/com/fueled/reclaim/samples/items/LoadingAdapterItem.kt
+++ b/app/src/main/kotlin/com/fueled/reclaim/samples/items/LoadingAdapterItem.kt
@@ -1,0 +1,18 @@
+package com.fueled.reclaim.samples.items
+
+import com.fueled.reclaim.AdapterItem
+import com.fueled.reclaim.BaseViewHolder
+import com.fueled.reclaim.samples.R
+
+/**
+ * Created by shashank@fueled.com on 08/04/2020.
+ */
+class LoadingAdapterItem : AdapterItem<LoadingViewHolder>() {
+
+    override val layoutId = R.layout.item_loading
+
+    override fun onCreateViewHolder(view: View) = LoadingViewHolder(view)
+
+}
+
+class LoadingViewHolder(view: View) : BaseViewHolder(view)

--- a/app/src/main/res/layout/item_loading.xml
+++ b/app/src/main/res/layout/item_loading.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProgressBar xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center" />

--- a/reclaim/src/main/kotlin/com/fueled/reclaim/AdapterItem.kt
+++ b/reclaim/src/main/kotlin/com/fueled/reclaim/AdapterItem.kt
@@ -46,7 +46,7 @@ abstract class AdapterItem<T2 : BaseViewHolder> {
      * This method should update the contents of the [ViewHolder#itemView][android.support.v7.widget.RecyclerView.ViewHolder.itemView]
      * to reflect the data of this item.
      */
-    abstract fun updateItemViews(viewHolder: T2)
+    open fun updateItemViews(viewHolder: T2) {}
 
     /**
      * This method should update the contents of the [ViewHolder#itemView][android.support.v7.widget.RecyclerView.ViewHolder.itemView]


### PR DESCRIPTION
I am thinking that we should make the `updateItemViews` method optional since in some cases, we do not require it but are still forced to implement it; cases like a loading item or a divider item.